### PR TITLE
Fix reversed merge op

### DIFF
--- a/lib/soupkitchen/config.rb
+++ b/lib/soupkitchen/config.rb
@@ -76,8 +76,7 @@ class SoupKitchen::Config
   #
   # @return [Hash]
   def node_config(node_data)
-    profile  = node_data["profile"]
-    node_data.merge! @data["profiles"].find {|p| p["name"] == profile}
-    node_data
+    profile = @data['profiles'].find {|p| p['name'] == node_data['profile'] }
+    profile.merge(node_data)
   end
 end


### PR DESCRIPTION
With the merge reversed the name attribute from the profile array was taking precedence over the name attribute from the node array. This commit swaps back the merge operation for correct node/profile merge behavior.
