### PR TITLE
Add dummy ip to private networks

### DIFF
--- a/templates/oscar-init-skeleton/virtualbox/roles.yaml
+++ b/templates/oscar-init-skeleton/virtualbox/roles.yaml
@@ -2,7 +2,7 @@
 roles:
   pe-puppet-master:
     private_networks:
-      - {auto_network: true}
+      - {ip: '0.0.0.0', auto_network: true}
     provider:
       type: virtualbox
       customize:
@@ -13,7 +13,7 @@ roles:
 
   pe-puppet-agent:
     private_networks:
-      - {auto_network: true}
+      - {ip: '0.0.0.0', auto_network: true}
     provisioners:
       - {type: hosts}
       - {type: pe_bootstrap}


### PR DESCRIPTION
Passing a dummy ip of `0.0.0.0` allows `auto_network` to function under Vagrant
1.2.3 -- 1.2.7 (and possibly newer versions).
