### PR TITLE
Modify Vagrantfile to gracefully allow sans-plugin

### DIFF
--- a/templates/oscar-init-skeleton/Vagrantfile
+++ b/templates/oscar-init-skeleton/Vagrantfile
@@ -2,4 +2,4 @@
 # vi: set ft=ruby :
 
 Vagrant.require_plugin('oscar')
-Vagrant.configure('2', &Oscar.run(File.expand_path('../config', __FILE__)))
+Vagrant.configure('2', &Oscar.run(File.expand_path('../config', __FILE__))) if defined? Oscar


### PR DESCRIPTION
Previously, running a command such as `vagrant plugin list` while in a directory with an Oscar-template-generated Vagrantfile would cause Vagrant to error out, as the Vagrant.require_plugin('oscar') command would omit the plugin due to being run in a non-plugin-enabled mode, and the subsequent reference to the Oscar class would then error out.

This commit appends `if defined? Oscar` to the `Vagrant.configure` call, thus gracefully no-op'ing if plugin loading is disabled.
