### PR TITLE
Add vmware_fusion templates for oscar init

### DIFF
--- a/templates/oscar-init-skeleton/vmware_fusion/boxes.yaml
+++ b/templates/oscar-init-skeleton/vmware_fusion/boxes.yaml
@@ -1,0 +1,10 @@
+---
+# Boxes from http://puppet-vagrant-boxes.puppetlabs.com/
+# Updated: 2014-09-16
+boxes:
+  'fedora-18-x64-vf503-nocm': 'http://puppet-vagrant-boxes.puppetlabs.com/fedora-18-x64-vf503-nocm.box'
+  'centos-64-x64-fusion503-nocm': 'http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-fusion503-nocm.box'
+  'debian-607-x64-vf503-nocm': 'http://puppet-vagrant-boxes.puppetlabs.com/debian-607-x64-vf503-nocm.box'
+  'debian-70rc1-x64-vf503-nocm': 'http://puppet-vagrant-boxes.puppetlabs.com/debian-70rc1-x64-vf503-nocm.box'
+  'ubuntu-server-10044-x64-fusion503-nocm': 'http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-fusion503-nocm.box'
+  'ubuntu-svr-12042-x64-vf503-nocm': 'http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-svr-12042-x64-vf503-nocm.box'

--- a/templates/oscar-init-skeleton/vmware_fusion/roles.yaml
+++ b/templates/oscar-init-skeleton/vmware_fusion/roles.yaml
@@ -1,0 +1,19 @@
+---
+roles:
+  pe-puppet-master:
+    private_networks:
+      - {ip: '0.0.0.0', auto_network: true}
+    provider:
+      type: vmware_fusion
+      customize:
+        - [modifyvm, !ruby/sym id, '--memory', 1024]
+    provisioners:
+      - {type: hosts}
+      - {type: pe_bootstrap, role: !ruby/sym master}
+
+  pe-puppet-agent:
+    private_networks:
+      - {ip: '0.0.0.0', auto_network: true}
+    provisioners:
+      - {type: hosts}
+      - {type: pe_bootstrap}


### PR DESCRIPTION
- Essentially the same as the VirtualBox template, but links have
  been updated with appropriate links.  Note that the following boxes
  are not published for Fusion:
  centos-59-x64
  sles-11sp1-x64
- Update the provider in roles.yaml to vmware_fusion
