### PR TITLE
Update dependencies and oscar version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,22 @@
 CHANGELOG
 =========
 
+0.4.3
+-----
+
+2016-01-07
+
+This is a backwards-compatible dependency update release. The updated
+dependency versions are all bugfix and feature releases, no major version
+changes. The dependencies are being updated in order to ensure that critical
+bug fixes in e.g. the pe_build plugin are included when validating oscar's
+dependencies.
+
+  * Update vagrant-hosts dependency to 2.6.1
+  * Update vagrant-pe_build dependency to 0.13.6
+  * Update vagrant-auto_network dependency to 1.0.2
+  * Update vagrant-config_builder dependency to 0.15.1
+
 0.4.2
 -----
 

--- a/lib/oscar/version.rb
+++ b/lib/oscar/version.rb
@@ -1,3 +1,3 @@
 module Oscar
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end

--- a/oscar.gemspec
+++ b/oscar.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |gem|
   gem.email    = 'adrien@somethingsinistral.net'
   gem.homepage = 'https://github.com/adrienthebo/oscar'
 
-  gem.add_dependency 'vagrant-hosts',          '~> 2.1'
-  gem.add_dependency 'vagrant-pe_build',       '~> 0.8'
-  gem.add_dependency 'vagrant-auto_network',   '~> 1.0'
-  gem.add_dependency 'vagrant-config_builder', '~> 0.9'
+  gem.add_dependency 'vagrant-hosts',          '~> 2.6.1'
+  gem.add_dependency 'vagrant-pe_build',       '~> 0.13.6'
+  gem.add_dependency 'vagrant-auto_network',   '~> 1.0.2'
+  gem.add_dependency 'vagrant-config_builder', '~> 0.15.1'
 
   gem.files        = %x{git ls-files -z}.split("\0")
   gem.require_path = 'lib'


### PR DESCRIPTION
This is a backwards-compatible dependency update commit. The updated
dependency versions are all bugfix and feature releases, no major
version changes. The dependencies are being updated in order to ensure
that critical bug fixes in e.g. the pe_build plugin are included when
validating oscar's dependencies.