### PR TITLE
Add description to plugin

### DIFF
--- a/lib/oscar/plugin.rb
+++ b/lib/oscar/plugin.rb
@@ -3,6 +3,9 @@ require 'vagrant'
 module Oscar
   class Plugin < Vagrant.plugin('2')
     name 'oscar'
+    description <<-DESC
+Oscar is a set of Vagrant plugins and templates that build up a full Puppet Enterprise environment based on top of Vagrant.
+DESC
 
     command(:oscar) do
       require_relative 'command'


### PR DESCRIPTION
Right now the plugin has no description:

<img width="1021" alt="screenshot 2017-03-01 09 25 14" src="https://cloud.githubusercontent.com/assets/1064715/23453629/fc98f514-fe60-11e6-90de-3596c52f22d2.png">

This adds a basic description taken from the README