### PR TITLE
(feat) Add vagrant-bolt as a gem dependency

### DIFF
--- a/lib/oscar.rb
+++ b/lib/oscar.rb
@@ -3,6 +3,8 @@ module Oscar
   require 'vagrant-pe_build'
   require 'vagrant-auto_network'
   require 'vagrant-config_builder'
+  require 'rubygems/requirement'
+  require 'vagrant-bolt' if Gem::Requirement.new('>= 2.2.0').satisfied_by?(Gem::Version.new(Vagrant::VERSION))
 
   require 'oscar/version'
   require 'oscar/plugin'

--- a/oscar.gemspec
+++ b/oscar.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'vagrant-pe_build',       '>= 0.19.0', '< 1.0'
   gem.add_dependency 'vagrant-auto_network',   '~> 1.0'
   gem.add_dependency 'vagrant-config_builder', '~> 1.3'
+  gem.add_dependency 'vagrant-bolt',           '~> 0.1'
 
   gem.files        = %x{git ls-files -z}.split("\0")
   gem.require_path = 'lib'


### PR DESCRIPTION
This commit adds a new dependency to this module: vagrant-bolt. This
new dependency will install the `vagrant-bolt` plugin and load it if
the vagrant version is higher than 2.2.