### PR TITLE
Update to vagrant-bolt 0.2.0

### DIFF
--- a/lib/oscar/version.rb
+++ b/lib/oscar/version.rb
@@ -1,3 +1,3 @@
 module Oscar
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.6.1'.freeze
 end

--- a/oscar.gemspec
+++ b/oscar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'vagrant-pe_build',       '>= 0.19.0', '< 1.0'
   gem.add_dependency 'vagrant-auto_network',   '~> 1.0'
   gem.add_dependency 'vagrant-config_builder', '~> 1.3'
-  gem.add_dependency 'vagrant-bolt',           '~> 0.1'
+  gem.add_dependency 'vagrant-bolt',           '~> 0.2'
 
   gem.files        = %x{git ls-files -z}.split("\0")
   gem.require_path = 'lib'


### PR DESCRIPTION
Prior to this commit, vagrant-bolt 0.1.x was used. This commit updates
to vagrant-bolt 0.2.x to be compatible with bolt 2.0.0+.